### PR TITLE
Bugfix: Give EditMask temp files unique filenames

### DIFF
--- a/nodes/edit_mask.py
+++ b/nodes/edit_mask.py
@@ -7,6 +7,7 @@ import os
 import folder_paths 
 import node_helpers
 import hashlib
+from uuid import uuid4
 
 # Tensor to PIL
 def tensor2pil(image):
@@ -26,7 +27,7 @@ def tensor_to_hash(tensor):
     return hash_value
 
 
-def create_temp_file(image):
+def create_temp_file(image, uuid):
     output_dir = folder_paths.get_temp_directory()
 
     (
@@ -35,7 +36,7 @@ def create_temp_file(image):
             counter,
             subfolder,
             _,
-        ) = folder_paths.get_save_image_path('material', output_dir)
+        ) = folder_paths.get_save_image_path(f'material_{uuid}', output_dir)
 
     
     image=tensor2pil(image)
@@ -59,6 +60,7 @@ class EditMask:
 
     def __init__(self):
         self.image_id = None
+        self.uuid = str(uuid4())
 
     @classmethod
     def INPUT_TYPES(s):
@@ -117,13 +119,13 @@ class EditMask:
                 image_path = os.path.join(base_dir,subfolder, name)
         
         if image_path==None:
-            image_path,images=create_temp_file(image)
+            image_path,images=create_temp_file(image, self.uuid)
 
         print('#image_path',os.path.exists(image_path),image_path)
         # image_path = folder_paths.get_annotated_filepath(image) #文件名
         
         if not os.path.exists(image_path):
-            image_path,images=create_temp_file(image)
+            image_path,images=create_temp_file(image, self.uuid)
 
 
         img = node_helpers.pillow(Image.open, image_path)


### PR DESCRIPTION
There is a bug in the (very useful) EditMask node.

If more than 1 EditMask node exists within a workflow and they are loaded at a similar time, they end up referencing the same temp file, meaning that nodes after the first instance loaded will not load the correct image for editing:

![edit_mask_name_bug](https://github.com/user-attachments/assets/75ca3af7-897f-4889-91b6-c1141ef40b75)

this is also shown in the debug output in the console:

```
#image_path True /home/user/git/ComfyUI/temp/material_00001.png
--
#image_path True /home/user/git/ComfyUI/temp/material_00001.png
```

This bugfix gives each EditMask instance a unique identifier (UUID4)  and uses this for temp file naming, which fixes the issue:
![edit_mask_name_fix](https://github.com/user-attachments/assets/e2b24f94-bdb9-4929-b052-5fd69a37b634)

```
#image_path True /home/user/git/ComfyUI/temp/material_b0571d36-37b2-4692-b3b6-c533327e0847_00001.png
--
#image_path True /home/user/git/ComfyUI/temp/material_a11ea9f0-a088-48f1-af58-4c8b85b33792_00001.png
```
